### PR TITLE
Guard against NaN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ NYC		:= $(NODE_BIN)/nyc
 #
 # Files
 #
-JS_FILES	:= index.js
 TEST_FILES	:= test/index.js
+JS_FILES	:= index.js $(TEST_FILES)
 CLEAN_FILES	+= node_modules
 
 #

--- a/index.js
+++ b/index.js
@@ -21,22 +21,26 @@ var assert = require('assert-plus');
  */
 function Ewma(halfLifeMs, initialValue, clock) {
     assert.number(halfLifeMs, 'halfLifeMs');
+    assert.ok(!Number.isNaN(halfLifeMs), 'halfLifeMs can not be NaN');
     assert.optionalNumber(initialValue, 'initialValue');
-    assert.optionalObject(clock, 'clock');
+    assert.ok(!Number.isNaN(initialValue), 'initialValue can not be NaN');
 
-    if (clock) {
+    if (clock !== undefined) {
         assert.func(clock.now, 'clock.now');
     }
 
     this._decay = halfLifeMs;
     this._ewma = initialValue || 0;
     this._clock = clock || Date;
-    this._stamp = (typeof initialValue === 'number') ? clock.now() : 0;
+    this._stamp = (typeof initialValue === 'number') ? this._clock.now() : 0;
 }
 
 module.exports = Ewma;
 
 Ewma.prototype.insert = function insert(x) {
+    assert.number(x, 'x');
+    assert.ok(!Number.isNaN(x), 'x can not be NaN');
+
     var self = this;
     var now = self._clock.now();
     var elapsed = now - self._stamp;
@@ -57,6 +61,9 @@ Ewma.prototype.insert = function insert(x) {
 };
 
 Ewma.prototype.reset = function reset(x) {
+    assert.number(x, 'x');
+    assert.ok(!Number.isNaN(x), 'x can not be NaN');
+
     var self = this;
     self._stamp = self._clock.now();
     self._ewma = x;

--- a/test/index.js
+++ b/test/index.js
@@ -1,45 +1,63 @@
-var EWMA = require('../index.js')
-var test = require('tape')
+'use strict';
 
-test('Should half life', function(t) {
-  var NOW = 10000000;
-  var clock = {
-    now: function() {
-      return NOW;
+var EWMA = require('../index.js');
+var test = require('tape');
+
+test('Should half life', function (t) {
+    var NOW = 10000000;
+    var clock = {
+        now: function () {
+            return NOW;
+        }
+    };
+    var e = new EWMA(1, 10, clock);
+    var shouldBe = 10;
+    t.equal(e.value(), shouldBe);
+    NOW++;
+    var i;
+
+    for (i = 1; i < 100; i++, NOW++) {
+        shouldBe = shouldBe * 0.5 + i * 0.5;
+        e.insert(i);
+        t.equal(e.value(), shouldBe);
     }
-  }
-  var e = new EWMA(1, 10, clock)
-  var shouldBe = 10;
-  t.equal(e.value(), shouldBe)
-  NOW++
-  var i;
-  for(i = 1; i < 100; i++, NOW++) {
-    shouldBe = shouldBe * .5 + i * .5
-    e.insert(i)
-    t.equal(e.value(), shouldBe)
-  }
 
-  t.comment("reset")
-  e.reset(0)
-  shouldBe = 0;
-  t.equal(e.value(), shouldBe)
-  NOW+=1
-  for(i=1; i < 100; i++, NOW+=1) {
-    shouldBe = shouldBe * .5 + i * .5
-    e.insert(i)
-    t.equal(e.value(), shouldBe)
-  }
+    t.comment('reset');
+    e.reset(0);
+    shouldBe = 0;
+    t.equal(e.value(), shouldBe);
+    NOW += 1;
 
-  t.comment("new")
-  var e = new EWMA(2, undefined, clock)
-  shouldBe = 1
-  e.insert(1)
-  t.equal(e.value(), shouldBe)
-  NOW+=2
-  for(i=2; i < 100; i++, NOW+=2) {
-    shouldBe = shouldBe * .5 + i * .5
-    e.insert(i)
-    t.equal(e.value(), shouldBe)
-  }
-  t.end()
-})
+    for (i = 1; i < 100; i++, NOW += 1) {
+        shouldBe = shouldBe * 0.5 + i * 0.5;
+        e.insert(i);
+        t.equal(e.value(), shouldBe);
+    }
+
+    t.comment('new');
+    e = new EWMA(2, undefined, clock);
+    shouldBe = 1;
+    e.insert(1);
+    t.equal(e.value(), shouldBe);
+    NOW += 2;
+
+    for (i = 2; i < 100; i++, NOW += 2) {
+        shouldBe = shouldBe * 0.5 + i * 0.5;
+        e.insert(i);
+        t.equal(e.value(), shouldBe);
+    }
+    t.end();
+});
+
+test('Guard against NaN', function (t) {
+    t.throws(EWMA.bind({}, NaN, 0, Date), 'opts.halfLifeMs');
+    t.throws(EWMA.bind({}, 100, NaN, Date), 'opts.initialValue');
+    t.doesNotThrow(EWMA.bind({}, 100, 0, Date));
+
+    var e = new EWMA(100, 0);
+    t.throws(e.insert.bind(e, NaN), 'insert(NaN)');
+    t.doesNotThrow(e.insert.bind(e, 0), 'insert(0)');
+    t.throws(e.reset.bind(e, NaN), 'reset(NaN)');
+    t.doesNotThrow(e.reset.bind(e, 0), 'reset(0)');
+    t.end();
+});


### PR DESCRIPTION
NaN is infectious for this algorithm. Once the EWMA is set to NaN, it
will be NaN for the rest of time until `reset` is called.

* Put gaurds against NaN in all functions
* Implement tests
* Add test file to style checks
* Fix clock scrubbing to be compatible with `Date`